### PR TITLE
fix: torch compile more stable on linux

### DIFF
--- a/src/torch_2dtm/cross_correlate.py
+++ b/src/torch_2dtm/cross_correlate.py
@@ -1,6 +1,7 @@
 """Cross-correlation functions."""
 
 import torch
+import platform
 import einops
 from einops._torch_specific import allow_ops_in_compiled_graph
 from torch_fourier_slice import extract_central_slices_rfft_3d
@@ -9,7 +10,11 @@ from torch_2dtm.utils import normalize_template_projection
 
 # compile normalization utility function
 allow_ops_in_compiled_graph()
-COMPILE_BACKEND = "inductor"
+if platform.system() == "Linux":
+    COMPILE_BACKEND = "aot_eager"  # More stable than inductor on Linux
+else:
+    COMPILE_BACKEND = "inductor"  # inductor for macOS
+
 normalize_template_projection_compiled = torch.compile(
     normalize_template_projection, backend=COMPILE_BACKEND
 )


### PR DESCRIPTION
Changed the compile backend for linux to something more stable to avoid memory issues.